### PR TITLE
CDK-944: Reading parquet datasets fails after schema evolution

### DIFF
--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/ParquetFileSystemDatasetReader.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/ParquetFileSystemDatasetReader.java
@@ -15,6 +15,12 @@
  */
 package org.kitesdk.data.spi.filesystem;
 
+
+import java.util.NoSuchElementException;
+
+import org.apache.hadoop.conf.Configuration;
+import org.kitesdk.data.DatasetIOException;
+import org.kitesdk.data.spi.DataModelUtil;
 import org.kitesdk.data.spi.ReaderWriterState;
 import org.kitesdk.data.DatasetReaderException;
 import org.kitesdk.data.spi.AbstractDatasetReader;
@@ -30,12 +36,14 @@ import org.apache.hadoop.fs.Path;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import parquet.avro.AvroParquetReader;
+import parquet.avro.AvroReadSupport;
 
 class ParquetFileSystemDatasetReader<E extends IndexedRecord> extends AbstractDatasetReader<E> {
 
   private FileSystem fileSystem;
   private Path path;
   private Schema schema;
+  private Schema readerSchema;
   private Class<E> type;
 
   private ReaderWriterState state;
@@ -59,6 +67,7 @@ class ParquetFileSystemDatasetReader<E extends IndexedRecord> extends AbstractDa
     this.path = path;
     this.schema = schema;
     this.type = type;
+    this.readerSchema = DataModelUtil.getReaderSchema(type, schema);
 
     this.state = ReaderWriterState.NEW;
   }
@@ -71,8 +80,10 @@ class ParquetFileSystemDatasetReader<E extends IndexedRecord> extends AbstractDa
     LOG.debug("Opening reader on path:{}", path);
 
     try {
+      final Configuration conf = fileSystem.getConf();
+      AvroReadSupport.setAvroReadSchema(conf, readerSchema);
       reader = new AvroParquetReader<E>(
-          fileSystem.getConf(), fileSystem.makeQualified(path));
+          conf, fileSystem.makeQualified(path));
     } catch (IOException e) {
       throw new DatasetReaderException("Unable to create reader path:" + path, e);
     }

--- a/kite-data/kite-data-core/src/test/avro/value.avsc
+++ b/kite-data/kite-data-core/src/test/avro/value.avsc
@@ -1,0 +1,19 @@
+{
+  "name": "Value",
+  "namespace": "org.kitesdk.data.event",
+  "type": "record",
+  "doc": "A small, single valued event",
+  "fields": [
+    {
+      "name": "id",
+      "type": ["null", "string"],
+      "default" : null,
+      "doc": "Id of the event"
+    },
+    {
+      "name": "value",
+      "type": "long",
+      "doc": "A value"
+    }
+  ]
+}

--- a/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/DatasetTestUtilities.java
+++ b/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/DatasetTestUtilities.java
@@ -31,7 +31,6 @@ import java.util.Set;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecordBuilder;
-import org.apache.avro.util.Utf8;
 import org.junit.Assert;
 import org.kitesdk.data.View;
 import org.kitesdk.data.spi.InitializeAccessor;
@@ -41,6 +40,7 @@ public class DatasetTestUtilities {
 
   public final static Schema STRING_SCHEMA = loadSchema("schema/string.avsc");
   public final static Schema USER_SCHEMA = loadSchema("schema/user.avsc");
+  public final static Schema OLD_VALUE_SCHEMA = loadSchema("schema/old_value.avsc");
   public final static URI USER_SCHEMA_URL = findSchemaURI("schema/user.avsc");
 
   private static Schema loadSchema(String resource) {

--- a/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestReadParquetAfterSchemaEvolution.java
+++ b/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestReadParquetAfterSchemaEvolution.java
@@ -17,24 +17,23 @@
 package org.kitesdk.data.spi.filesystem;
 
 import com.google.common.io.Files;
-import java.io.IOException;
-
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.LocalFileSystem;
 import org.apache.hadoop.fs.Path;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
-import org.kitesdk.data.Dataset;
-import org.kitesdk.data.DatasetDescriptor;
-import org.kitesdk.data.DatasetReader;
-import org.kitesdk.data.DatasetWriter;
-import org.kitesdk.data.TestDatasetReaders;
+import org.kitesdk.data.*;
+import org.kitesdk.data.event.Value;
+import org.kitesdk.data.spi.DefaultConfiguration;
 import org.kitesdk.data.spi.filesystem.DatasetTestUtilities.RecordValidator;
 
-public class TestWriteReflectReadGeneric extends TestDatasetReaders<GenericRecord> {
+import java.io.IOException;
+
+public class TestReadParquetAfterSchemaEvolution extends TestDatasetReaders<GenericRecord> {
 
   private static final int totalRecords = 100;
   protected static FileSystem fs = null;
@@ -46,15 +45,24 @@ public class TestWriteReflectReadGeneric extends TestDatasetReaders<GenericRecor
     Configuration conf = new Configuration();
     fs = FileSystem.getLocal(conf);
     testDirectory = new Path(Files.createTempDir().getAbsolutePath());
-    FileSystemDatasetRepository repo = new FileSystemDatasetRepository(conf, testDirectory);
-    Dataset<MyRecord> writerDataset = repo.create("ns", "test", new DatasetDescriptor.Builder()
-                                   .schema(MyRecord.class)
-                                   .build(), MyRecord.class);
-    DatasetWriter<MyRecord> writer = writerDataset.newWriter();
-    for (int i = 0; i < totalRecords; i++) {
-      writer.write(new MyRecord(String.valueOf(i), i));
+    FileSystemDatasetRepository repo = new FileSystemDatasetRepository(conf,
+        testDirectory);
+    Dataset<GenericRecord> writerDataset = repo.create("ns", "test", new DatasetDescriptor.Builder()
+                                   .schema(DatasetTestUtilities.OLD_VALUE_SCHEMA)
+                                   .format(Formats.PARQUET)
+                                   .build(), GenericRecord.class);
+    
+    DatasetWriter<GenericRecord> writer = writerDataset.newWriter();
+    
+    GenericRecord record = new GenericData.Record(DatasetTestUtilities.OLD_VALUE_SCHEMA);
+    for (long i = 0; i < totalRecords; i++) {
+      record.put("value", Long.valueOf(i));
+      writer.write(record);
     }
     writer.close();
+    
+    repo.update("ns", "test", new DatasetDescriptor.Builder(writerDataset.getDescriptor())
+      .schema(Value.class).build());
 
     readerDataset = repo.load("ns", "test", GenericRecord.class);
   }
@@ -80,24 +88,9 @@ public class TestWriteReflectReadGeneric extends TestDatasetReaders<GenericRecor
 
       @Override
       public void validate(GenericRecord record, int recordNum) {
-        Assert.assertEquals(GenericData.Record.class, record.getClass());
-        Assert.assertEquals(String.valueOf(recordNum), record.get("text").toString());
-        Assert.assertEquals(recordNum, record.get("value"));
+        Assert.assertEquals(null, record.get("id"));
+        Assert.assertEquals(Long.valueOf(recordNum), record.get("value"));
       }
     };
-  }
-
-  public static class MyRecord {
-
-    private String text;
-    private int value;
-
-    public MyRecord() {
-    }
-
-    public MyRecord(String text, int value) {
-      this.text = text;
-      this.value = value;
-    }
   }
 }

--- a/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestWriteSpecificReadGeneric.java
+++ b/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestWriteSpecificReadGeneric.java
@@ -17,8 +17,6 @@
 package org.kitesdk.data.spi.filesystem;
 
 import com.google.common.io.Files;
-import java.io.IOException;
-
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.hadoop.conf.Configuration;
@@ -27,36 +25,37 @@ import org.apache.hadoop.fs.Path;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
-import org.kitesdk.data.Dataset;
-import org.kitesdk.data.DatasetDescriptor;
-import org.kitesdk.data.DatasetReader;
-import org.kitesdk.data.DatasetWriter;
-import org.kitesdk.data.TestDatasetReaders;
+import org.kitesdk.data.*;
+import org.kitesdk.data.event.StandardEvent;
 import org.kitesdk.data.spi.filesystem.DatasetTestUtilities.RecordValidator;
 
-public class TestWriteReflectReadGeneric extends TestDatasetReaders<GenericRecord> {
+import java.io.IOException;
+
+public class TestWriteSpecificReadGeneric extends TestDatasetReaders<GenericData.Record> {
 
   private static final int totalRecords = 100;
   protected static FileSystem fs = null;
   protected static Path testDirectory = null;
-  protected static Dataset<GenericRecord> readerDataset;
+  protected static Dataset<GenericData.Record> readerDataset;
 
   @BeforeClass
   public static void setup() throws IOException {
     Configuration conf = new Configuration();
     fs = FileSystem.getLocal(conf);
     testDirectory = new Path(Files.createTempDir().getAbsolutePath());
-    FileSystemDatasetRepository repo = new FileSystemDatasetRepository(conf, testDirectory);
-    Dataset<MyRecord> writerDataset = repo.create("ns", "test", new DatasetDescriptor.Builder()
-                                   .schema(MyRecord.class)
-                                   .build(), MyRecord.class);
-    DatasetWriter<MyRecord> writer = writerDataset.newWriter();
-    for (int i = 0; i < totalRecords; i++) {
-      writer.write(new MyRecord(String.valueOf(i), i));
+    FileSystemDatasetRepository repo = new FileSystemDatasetRepository(conf,
+        testDirectory);
+    Dataset<StandardEvent> writerDataset = repo.create("ns", "test", new DatasetDescriptor.Builder()
+                                   .schema(StandardEvent.class)
+                                   .build(), StandardEvent.class);
+    DatasetWriter<StandardEvent> writer = writerDataset.newWriter();
+    for (long i = 0; i < totalRecords; i++) {
+      String text = String.valueOf(i);
+      writer.write(new StandardEvent(text, text, i, text, text, i));
     }
     writer.close();
 
-    readerDataset = repo.load("ns", "test", GenericRecord.class);
+    readerDataset = repo.load("ns", "test", GenericData.Record.class);
   }
 
   @AfterClass
@@ -65,7 +64,7 @@ public class TestWriteReflectReadGeneric extends TestDatasetReaders<GenericRecor
   }
 
   @Override
-  public DatasetReader<GenericRecord> newReader() throws IOException {
+  public DatasetReader<GenericData.Record> newReader() throws IOException {
     return readerDataset.newReader();
   }
 
@@ -75,29 +74,19 @@ public class TestWriteReflectReadGeneric extends TestDatasetReaders<GenericRecor
   }
 
   @Override
-  public RecordValidator<GenericRecord> getValidator() {
-    return new RecordValidator<GenericRecord>() {
+  public RecordValidator<GenericData.Record> getValidator() {
+    return new RecordValidator<GenericData.Record>() {
 
       @Override
-      public void validate(GenericRecord record, int recordNum) {
+      public void validate(GenericData.Record record, int recordNum) {
         Assert.assertEquals(GenericData.Record.class, record.getClass());
-        Assert.assertEquals(String.valueOf(recordNum), record.get("text").toString());
-        Assert.assertEquals(recordNum, record.get("value"));
+        Assert.assertEquals(String.valueOf(recordNum), record.get("event_initiator").toString());
+        Assert.assertEquals(String.valueOf(recordNum), record.get("event_name").toString());
+        Assert.assertEquals(Long.valueOf(recordNum), record.get("user_id"));
+        Assert.assertEquals(String.valueOf(recordNum), record.get("session_id").toString());
+        Assert.assertEquals(String.valueOf(recordNum), record.get("ip").toString());
+        Assert.assertEquals(Long.valueOf(recordNum), record.get("timestamp"));
       }
     };
-  }
-
-  public static class MyRecord {
-
-    private String text;
-    private int value;
-
-    public MyRecord() {
-    }
-
-    public MyRecord(String text, int value) {
-      this.text = text;
-      this.value = value;
-    }
   }
 }

--- a/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestWriteSpecificReadGenericParquet.java
+++ b/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestWriteSpecificReadGenericParquet.java
@@ -17,8 +17,6 @@
 package org.kitesdk.data.spi.filesystem;
 
 import com.google.common.io.Files;
-import java.io.IOException;
-
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.hadoop.conf.Configuration;
@@ -27,14 +25,13 @@ import org.apache.hadoop.fs.Path;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
-import org.kitesdk.data.Dataset;
-import org.kitesdk.data.DatasetDescriptor;
-import org.kitesdk.data.DatasetReader;
-import org.kitesdk.data.DatasetWriter;
-import org.kitesdk.data.TestDatasetReaders;
+import org.kitesdk.data.*;
+import org.kitesdk.data.event.StandardEvent;
 import org.kitesdk.data.spi.filesystem.DatasetTestUtilities.RecordValidator;
 
-public class TestWriteReflectReadGeneric extends TestDatasetReaders<GenericRecord> {
+import java.io.IOException;
+
+public class TestWriteSpecificReadGenericParquet extends TestDatasetReaders<GenericRecord> {
 
   private static final int totalRecords = 100;
   protected static FileSystem fs = null;
@@ -46,13 +43,16 @@ public class TestWriteReflectReadGeneric extends TestDatasetReaders<GenericRecor
     Configuration conf = new Configuration();
     fs = FileSystem.getLocal(conf);
     testDirectory = new Path(Files.createTempDir().getAbsolutePath());
-    FileSystemDatasetRepository repo = new FileSystemDatasetRepository(conf, testDirectory);
-    Dataset<MyRecord> writerDataset = repo.create("ns", "test", new DatasetDescriptor.Builder()
-                                   .schema(MyRecord.class)
-                                   .build(), MyRecord.class);
-    DatasetWriter<MyRecord> writer = writerDataset.newWriter();
-    for (int i = 0; i < totalRecords; i++) {
-      writer.write(new MyRecord(String.valueOf(i), i));
+    FileSystemDatasetRepository repo = new FileSystemDatasetRepository(conf,
+        testDirectory);
+    Dataset<StandardEvent> writerDataset = repo.create("ns", "test", new DatasetDescriptor.Builder()
+                                   .schema(StandardEvent.class)
+                                   .format(Formats.PARQUET)
+                                   .build(), StandardEvent.class);
+    DatasetWriter<StandardEvent> writer = writerDataset.newWriter();
+    for (long i = 0; i < totalRecords; i++) {
+      String text = String.valueOf(i);
+      writer.write(new StandardEvent(text, text, i, text, text, i));
     }
     writer.close();
 
@@ -80,24 +80,15 @@ public class TestWriteReflectReadGeneric extends TestDatasetReaders<GenericRecor
 
       @Override
       public void validate(GenericRecord record, int recordNum) {
-        Assert.assertEquals(GenericData.Record.class, record.getClass());
-        Assert.assertEquals(String.valueOf(recordNum), record.get("text").toString());
-        Assert.assertEquals(recordNum, record.get("value"));
+        // This doesn't work. Parquet will still instantiate the class
+        // Assert.assertEquals(GenericData.Record.class, record.getClass());
+        Assert.assertEquals(String.valueOf(recordNum), record.get("event_initiator").toString());
+        Assert.assertEquals(String.valueOf(recordNum), record.get("event_name").toString());
+        Assert.assertEquals(Long.valueOf(recordNum), record.get("user_id"));
+        Assert.assertEquals(String.valueOf(recordNum), record.get("session_id").toString());
+        Assert.assertEquals(String.valueOf(recordNum), record.get("ip").toString());
+        Assert.assertEquals(Long.valueOf(recordNum), record.get("timestamp"));
       }
     };
-  }
-
-  public static class MyRecord {
-
-    private String text;
-    private int value;
-
-    public MyRecord() {
-    }
-
-    public MyRecord(String text, int value) {
-      this.text = text;
-      this.value = value;
-    }
   }
 }

--- a/kite-data/kite-data-core/src/test/resources/schema/old_value.avsc
+++ b/kite-data/kite-data-core/src/test/resources/schema/old_value.avsc
@@ -1,0 +1,13 @@
+{
+  "name": "Value",
+  "namespace": "org.kitesdk.data.event",
+  "type": "record",
+  "doc": "A small, single valued event",
+  "fields": [
+    {
+      "name": "value",
+      "type": "long",
+      "doc": "A value"
+    }
+  ]
+}


### PR DESCRIPTION
- Added a test to demonstrate this bug
- Added setting of the parquet reader schema.

Conflicts:
    kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/ParquetFileSystemDatasetReader.java
