### PR TITLE
SD-1494: Fix SCM connection URL in Kite fork

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
   </contributors> 
 
   <scm>
-    <connection>scm:git:git://github.com/scalingdata/cdk.git</connection>
+    <connection>scm:git:git@github.com:scalingdata/cdk.git</connection>
     <url>https://github.com/scalingdata/cdk</url>
     <developerConnection>scm:git:git@github.com:scalingdata/cdk.git
     </developerConnection>


### PR DESCRIPTION
- I bungled the last fix, this one is for reals.
