### PR TITLE
SD-1507: Kite depends on Guava DiscreteDomains which were removed in ver...

### DIFF
--- a/kite-data/kite-data-core/pom.xml
+++ b/kite-data/kite-data-core/pom.xml
@@ -206,6 +206,12 @@
       <artifactId>mockito-all</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.kitesdk</groupId>
+      <artifactId>kite-test-shims</artifactId>
+      <scope>test</scope>
+      <version>0.15.0-cdh5.2.1-sd1.0.0-SNAPSHOT</version>
+    </dependency>
 
   </dependencies>
 

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/TimeDomain.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/TimeDomain.java
@@ -22,7 +22,7 @@ import com.google.common.base.Predicate;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
-import com.google.common.collect.DiscreteDomains;
+import com.google.common.collect.DiscreteDomain;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import java.util.Arrays;
@@ -175,7 +175,7 @@ public class TimeDomain {
     private final boolean acceptEqual;
 
     private TimeRangePredicateImpl(Range<Long> timeRange, boolean acceptEqual) {
-      this.range = Ranges.adjustClosed(timeRange, DiscreteDomains.longs());
+      this.range = Ranges.adjustClosed(timeRange, DiscreteDomain.longs());
       this.acceptEqual = acceptEqual;
 
       int length = partitioners.size();

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/partition/IntRangeFieldPartitioner.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/partition/IntRangeFieldPartitioner.java
@@ -16,7 +16,7 @@
 package org.kitesdk.data.spi.partition;
 
 import com.google.common.base.Predicate;
-import com.google.common.collect.DiscreteDomains;
+import com.google.common.collect.DiscreteDomain;
 import com.google.common.base.Objects;
 import com.google.common.collect.Sets;
 import com.google.common.primitives.Ints;
@@ -78,7 +78,7 @@ public class IntRangeFieldPartitioner extends FieldPartitioner<Integer, Integer>
       //   if this( 5 ) => 10 then this( 6 ) => 10, so 10 must be included
       return Ranges.transformClosed(
           Ranges.adjustClosed((Range<Integer>) predicate,
-              DiscreteDomains.integers()), this);
+              DiscreteDomain.integers()), this);
     } else {
       return null;
     }
@@ -113,7 +113,7 @@ public class IntRangeFieldPartitioner extends FieldPartitioner<Integer, Integer>
 
     } else if (predicate instanceof Range) {
       Range<Integer> adjusted = Ranges.adjustClosed(
-          (Range<Integer>) predicate, DiscreteDomains.integers());
+          (Range<Integer>) predicate, DiscreteDomain.integers());
       if (adjusted.hasLowerBound()) {
         int lower = adjusted.lowerEndpoint();
         int lowerIndex = apply(lower);

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/partition/RangeFieldPartitioner.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/partition/RangeFieldPartitioner.java
@@ -17,7 +17,7 @@ package org.kitesdk.data.spi.partition;
 
 import com.google.common.base.Predicate;
 import com.google.common.collect.DiscreteDomain;
-import com.google.common.collect.DiscreteDomains;
+import com.google.common.collect.DiscreteDomain;
 import java.util.Arrays;
 import java.util.List;
 import javax.annotation.Nullable;
@@ -228,7 +228,7 @@ public class RangeFieldPartitioner extends FieldPartitioner<String, String> {
 
     @Override
     public String maxValue() {
-      DiscreteDomains.integers();
+      DiscreteDomain.integers();
       return upperBounds.get(upperBounds.size() - 1);
     }
   }

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/partition/YearFieldPartitioner.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/partition/YearFieldPartitioner.java
@@ -16,7 +16,7 @@
 package org.kitesdk.data.spi.partition;
 
 import com.google.common.base.Predicate;
-import com.google.common.collect.DiscreteDomains;
+import com.google.common.collect.DiscreteDomain;
 import java.util.Calendar;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
@@ -51,7 +51,7 @@ public class YearFieldPartitioner extends CalendarFieldPartitioner {
     } else if (predicate instanceof Range) {
       return Ranges.transformClosed(
           Ranges.adjustClosed(
-              (Range<Long>) predicate, DiscreteDomains.longs()),
+              (Range<Long>) predicate, DiscreteDomain.longs()),
           this);
     } else {
       return null;
@@ -68,9 +68,9 @@ public class YearFieldPartitioner extends CalendarFieldPartitioner {
       return null;
     } else if (predicate instanceof Range) {
       //return Predicates.transformClosedConservative(
-      //    (Range<Long>) predicate, this, DiscreteDomains.integers());
+      //    (Range<Long>) predicate, this, DiscreteDomain.integers());
       Range<Long> adjusted = Ranges.adjustClosed(
-          (Range<Long>) predicate, DiscreteDomains.longs());
+          (Range<Long>) predicate, DiscreteDomain.longs());
       if (adjusted.hasLowerBound()) {
         long lower = adjusted.lowerEndpoint();
         int lowerImage = apply(lower);

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/predicates/Ranges.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/predicates/Ranges.java
@@ -119,22 +119,22 @@ public class Ranges {
       Range<C> range) {
     if (range.hasLowerBound()) {
       if (range.hasUpperBound()) {
-        return com.google.common.collect.Ranges.range(
+        return com.google.common.collect.Range.range(
             range.lowerEndpoint(),
             range.isLowerBoundOpen() ? BoundType.OPEN : BoundType.CLOSED,
             range.upperEndpoint(),
             range.isUpperBoundOpen() ? BoundType.OPEN : BoundType.CLOSED);
       } else {
-        return com.google.common.collect.Ranges.downTo(
+        return com.google.common.collect.Range.downTo(
             range.lowerEndpoint(),
             range.isLowerBoundOpen() ? BoundType.OPEN : BoundType.CLOSED);
       }
     } else if (range.hasUpperBound()) {
-      return com.google.common.collect.Ranges.upTo(
+      return com.google.common.collect.Range.upTo(
           range.upperEndpoint(),
           range.isUpperBoundOpen() ? BoundType.OPEN : BoundType.CLOSED);
     } else {
-      return com.google.common.collect.Ranges.all();
+      return com.google.common.collect.Range.all();
     }
   }
 }

--- a/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/predicates/TestRangeCharSequence.java
+++ b/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/predicates/TestRangeCharSequence.java
@@ -134,31 +134,31 @@ public class TestRangeCharSequence {
   public void testAsGuavaRange() {
     // some methods like asSet convert to Guava rather than reimplementing
     Assert.assertEquals("Should convert to guava singleton",
-        com.google.common.collect.Ranges.singleton("ab"),
+        com.google.common.collect.Range.singleton("ab"),
         Ranges.asGuavaRange(Ranges.singleton("ab")));
     Assert.assertEquals("Should convert to guava open",
-        com.google.common.collect.Ranges.open("ab", "cd"),
+        com.google.common.collect.Range.open("ab", "cd"),
         Ranges.asGuavaRange(Ranges.open("ab", "cd")));
     Assert.assertEquals("Should convert to guava closed",
-        com.google.common.collect.Ranges.closed("ab", "cd"),
+        com.google.common.collect.Range.closed("ab", "cd"),
         Ranges.asGuavaRange(Ranges.closed("ab", "cd")));
     Assert.assertEquals("Should convert to guava openClosed",
-        com.google.common.collect.Ranges.openClosed("ab", "cd"),
+        com.google.common.collect.Range.openClosed("ab", "cd"),
         Ranges.asGuavaRange(Ranges.openClosed("ab", "cd")));
     Assert.assertEquals("Should convert to guava closedOpen",
-        com.google.common.collect.Ranges.closedOpen("ab", "cd"),
+        com.google.common.collect.Range.closedOpen("ab", "cd"),
         Ranges.asGuavaRange(Ranges.closedOpen("ab", "cd")));
     Assert.assertEquals("Should convert to guava atLeast",
-        com.google.common.collect.Ranges.atLeast("ab"),
+        com.google.common.collect.Range.atLeast("ab"),
         Ranges.asGuavaRange(Ranges.atLeast("ab")));
     Assert.assertEquals("Should convert to guava greaterThan",
-        com.google.common.collect.Ranges.greaterThan("ab"),
+        com.google.common.collect.Range.greaterThan("ab"),
         Ranges.asGuavaRange(Ranges.greaterThan("ab")));
     Assert.assertEquals("Should convert to guava atMost",
-        com.google.common.collect.Ranges.atMost("cd"),
+        com.google.common.collect.Range.atMost("cd"),
         Ranges.asGuavaRange(Ranges.atMost("cd")));
     Assert.assertEquals("Should convert to guava lessThan",
-        com.google.common.collect.Ranges.lessThan("cd"),
+        com.google.common.collect.Range.lessThan("cd"),
         Ranges.asGuavaRange(Ranges.lessThan("cd")));
   }
 

--- a/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/predicates/TestRangeComparable.java
+++ b/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/predicates/TestRangeComparable.java
@@ -112,31 +112,31 @@ public class TestRangeComparable {
   public void testAsGuavaRange() {
     // some methods like asSet convert to Guava rather than reimplementing
     Assert.assertEquals("Should convert to guava singleton",
-        com.google.common.collect.Ranges.singleton(3),
+        com.google.common.collect.Range.singleton(3),
         Ranges.asGuavaRange(Ranges.singleton(3)));
     Assert.assertEquals("Should convert to guava open",
-        com.google.common.collect.Ranges.open(3, 5),
+        com.google.common.collect.Range.open(3, 5),
         Ranges.asGuavaRange(Ranges.open(3, 5)));
     Assert.assertEquals("Should convert to guava closed",
-        com.google.common.collect.Ranges.closed(3, 5),
+        com.google.common.collect.Range.closed(3, 5),
         Ranges.asGuavaRange(Ranges.closed(3, 5)));
     Assert.assertEquals("Should convert to guava openClosed",
-        com.google.common.collect.Ranges.openClosed(3, 5),
+        com.google.common.collect.Range.openClosed(3, 5),
         Ranges.asGuavaRange(Ranges.openClosed(3, 5)));
     Assert.assertEquals("Should convert to guava closedOpen",
-        com.google.common.collect.Ranges.closedOpen(3, 5),
+        com.google.common.collect.Range.closedOpen(3, 5),
         Ranges.asGuavaRange(Ranges.closedOpen(3, 5)));
     Assert.assertEquals("Should convert to guava atLeast",
-        com.google.common.collect.Ranges.atLeast(3),
+        com.google.common.collect.Range.atLeast(3),
         Ranges.asGuavaRange(Ranges.atLeast(3)));
     Assert.assertEquals("Should convert to guava greaterThan",
-        com.google.common.collect.Ranges.greaterThan(3),
+        com.google.common.collect.Range.greaterThan(3),
         Ranges.asGuavaRange(Ranges.greaterThan(3)));
     Assert.assertEquals("Should convert to guava atMost",
-        com.google.common.collect.Ranges.atMost(5),
+        com.google.common.collect.Range.atMost(5),
         Ranges.asGuavaRange(Ranges.atMost(5)));
     Assert.assertEquals("Should convert to guava lessThan",
-        com.google.common.collect.Ranges.lessThan(5),
+        com.google.common.collect.Range.lessThan(5),
         Ranges.asGuavaRange(Ranges.lessThan(5)));
   }
 

--- a/kite-data/kite-data-crunch/pom.xml
+++ b/kite-data/kite-data-crunch/pom.xml
@@ -216,6 +216,12 @@
       <type>pom</type>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.kitesdk</groupId>
+      <artifactId>kite-test-shims</artifactId>
+      <scope>test</scope>
+      <version>0.15.0-cdh5.2.1-sd1.0.0-SNAPSHOT</version>
+    </dependency>
 
     <!-- fix hbase/hive thrift version conflict -->
     <dependency>

--- a/kite-data/kite-data-hbase/pom.xml
+++ b/kite-data/kite-data-hbase/pom.xml
@@ -240,5 +240,11 @@
       <type>pom</type>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.kitesdk</groupId>
+      <artifactId>kite-test-shims</artifactId>
+      <scope>test</scope>
+      <version>0.15.0-cdh5.2.1-sd1.0.0-SNAPSHOT</version>
+    </dependency>
   </dependencies>
 </project>

--- a/kite-data/kite-data-hive/pom.xml
+++ b/kite-data/kite-data-hive/pom.xml
@@ -168,6 +168,13 @@
       <type>pom</type>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.kitesdk</groupId>
+      <artifactId>kite-test-shims</artifactId>
+      <scope>test</scope>
+      <version>0.15.0-cdh5.2.1-sd1.0.0-SNAPSHOT</version>
+    </dependency>
   </dependencies>
 
 </project>

--- a/kite-data/kite-data-mapreduce/pom.xml
+++ b/kite-data/kite-data-mapreduce/pom.xml
@@ -186,6 +186,13 @@
       <type>pom</type>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.kitesdk</groupId>
+      <artifactId>kite-test-shims</artifactId>
+      <scope>test</scope>
+      <version>0.15.0-cdh5.2.1-sd1.0.0-SNAPSHOT</version>
+    </dependency>
   </dependencies>
 
 </project>

--- a/kite-data/kite-data-spark/pom.xml
+++ b/kite-data/kite-data-spark/pom.xml
@@ -249,6 +249,13 @@
       </exclusions>
     </dependency>
 
+    <dependency>
+      <groupId>org.kitesdk</groupId>
+      <artifactId>kite-test-shims</artifactId>
+      <scope>test</scope>
+      <version>0.15.0-cdh5.2.1-sd1.0.0-SNAPSHOT</version>
+    </dependency>
+
   </dependencies>
 
 </project>

--- a/kite-morphlines/kite-morphlines-hadoop-core/pom.xml
+++ b/kite-morphlines/kite-morphlines-hadoop-core/pom.xml
@@ -63,6 +63,13 @@
       <artifactId>junit</artifactId>
       <scope>test</scope>
     </dependency>    
+
+    <dependency>
+      <groupId>org.kitesdk</groupId>
+      <artifactId>kite-test-shims</artifactId>
+      <scope>test</scope>
+      <version>0.15.0-cdh5.2.1-sd1.0.0-SNAPSHOT</version>
+    </dependency>
     
   </dependencies>
 </project>

--- a/kite-test-shims/pom.xml
+++ b/kite-test-shims/pom.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright 2013 Cloudera Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>kite-test-shims</artifactId>
+  <packaging>jar</packaging>
+
+  <parent>
+    <groupId>org.kitesdk</groupId>
+    <artifactId>kite-parent</artifactId>
+    <version>0.15.0-cdh5.2.1-sd1.0.0-SNAPSHOT</version>
+  </parent>
+
+  <name>Kite Test Shims Module</name>
+  <description>
+    Provide test shims needed to maintain compatability with MiniHDFSCluster.
+  </description>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.rat</groupId>
+        <artifactId>apache-rat-plugin</artifactId>
+      </plugin>
+    </plugins>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <configuration>
+            <compilerArgs>
+              <arg>-Werror</arg> <!-- fail on warnings -->
+              <arg>-Xlint:-options</arg> <!-- ignore cross-compilation warning -->
+              <arg>-Xlint:unchecked</arg>
+            </compilerArgs>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+  
+  <dependencies>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
+  </dependencies>
+
+  <reporting>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-project-info-reports-plugin</artifactId>
+        <reportSets>
+          <reportSet>
+            <inherited>false</inherited>
+            <reports>
+              <report>index</report>
+            </reports>
+          </reportSet>
+        </reportSets>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </reporting>
+
+</project>

--- a/kite-test-shims/src/main/java/com/google/common/io/LimitInputStream.java
+++ b/kite-test-shims/src/main/java/com/google/common/io/LimitInputStream.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2007 The Guava Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.common.io;
+
+import com.google.common.annotations.Beta;
+import com.google.common.base.Preconditions;
+
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * An InputStream that limits the number of bytes which can be read.
+ *
+ * @author Charles Fry
+ * @since 1.0
+ */
+@Beta
+public final class LimitInputStream extends FilterInputStream {
+
+  private long left;
+  private long mark = -1;
+
+  /**
+   * Wraps another input stream, limiting the number of bytes which can be read.
+   *
+   * @param in the input stream to be wrapped
+   * @param limit the maximum number of bytes to be read
+   */
+  public LimitInputStream(InputStream in, long limit) {
+    super(in);
+    Preconditions.checkNotNull(in);
+    Preconditions.checkArgument(limit >= 0, "limit must be non-negative");
+    left = limit;
+  }
+
+  @Override public int available() throws IOException {
+    return (int) Math.min(in.available(), left);
+  }
+
+  @Override public synchronized void mark(int readlimit) {
+    in.mark(readlimit);
+    mark = left;
+    // it's okay to mark even if mark isn't supported, as reset won't work
+  }
+
+  @Override public int read() throws IOException {
+    if (left == 0) {
+      return -1;
+    }
+
+    int result = in.read();
+    if (result != -1) {
+      --left;
+    }
+    return result;
+  }
+
+  @Override public int read(byte[] b, int off, int len) throws IOException {
+    if (left == 0) {
+      return -1;
+    }
+
+    len = (int) Math.min(len, left);
+    int result = in.read(b, off, len);
+    if (result != -1) {
+      left -= result;
+    }
+    return result;
+  }
+
+  @Override public synchronized void reset() throws IOException {
+    if (!in.markSupported()) {
+      throw new IOException("Mark not supported");
+    }
+    if (mark == -1) {
+      throw new IOException("Mark not set");
+    }
+
+    in.reset();
+    left = mark;
+  }
+
+  @Override public long skip(long n) throws IOException {
+    n = Math.min(n, left);
+    long skipped = in.skip(n);
+    left -= skipped;
+    return skipped;
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,7 @@
   <packaging>pom</packaging>
 
   <modules>
+    <module>kite-test-shims</module>
     <module>kite-hadoop-dependencies</module>
     <module>kite-hadoop-compatibility</module>
     <module>kite-hbase-dependencies</module>
@@ -145,7 +146,7 @@
     <vers.crunch-cdh5>${cdh.crunch.version}</vers.crunch-cdh5>
     <vers.findbugs.jsr305>2.0.1</vers.findbugs.jsr305>
     <vers.flume>${cdh.flume-ng.version}</vers.flume>
-    <vers.guava>11.0.2</vers.guava>
+    <vers.guava>15.0</vers.guava>
     <vers.hadoop1>1.2.1</vers.hadoop1>
     <vers.hadoop2>2.3.0</vers.hadoop2>
     <vers.hadoop-cdh4>2.0.0-cdh${cdh4.version}</vers.hadoop-cdh4>


### PR DESCRIPTION
...sion 15.0

This patch does the following:
- Updates the guava dependency to 0.15
- Updates uses of DiscreteDomains and Ranges to be compatible with Guava 0.15
- Adds a module that has a copy of Guava 0.11.0.2's LimitInputStream so that
  tests using HDFSMiniCluster still work.
- Updates POM files with kite-test-shims as a test time dependency where needed
