### PR TITLE
CDK-615: Permissions issue writing to a partitioned Hive external dataset

### DIFF
--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/FileSystemDataset.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/FileSystemDataset.java
@@ -199,11 +199,14 @@ public class FileSystemDataset<E> extends AbstractDataset<E> implements
     try {
       if (!fileSystem.exists(partitionDirectory)) {
         if (allowCreate) {
-          fileSystem.mkdirs(partitionDirectory);
           if (partitionListener != null) {
             partitionListener.partitionAdded(namespace, name,
                 toRelativeDirectory(key).toString());
           }
+
+          // ensure that the directory exists, it may or may not have been
+          // created by the partitionListener
+          fileSystem.mkdirs(partitionDirectory);
         } else {
           return null;
         }
@@ -321,6 +324,20 @@ public class FileSystemDataset<E> extends AbstractDataset<E> implements
       }
 
       Path newPartitionDirectory = newPath.getParent();
+
+      // We call this listener before we attempt to create any partition
+      // directories. This lets the listener decide how to create the
+      // directory, if desired. Hive managed datasets let the Hive
+      // metastore create them while external datasets create it
+      // locally
+      if (descriptor.isPartitioned() && partitionListener != null) {
+        String partition = newPartitionDirectory.toString();
+        if (!addedPartitions.contains(partition)) {
+          partitionListener.partitionAdded(namespace, name, partition);
+          addedPartitions.add(partition);
+        }
+      }
+
       try {
         if (!fileSystem.exists(newPartitionDirectory)) {
           fileSystem.mkdirs(newPartitionDirectory);
@@ -333,13 +350,6 @@ public class FileSystemDataset<E> extends AbstractDataset<E> implements
         }
       } catch (IOException e) {
         throw new DatasetIOException("Dataset merge failed", e);
-      }
-      if (descriptor.isPartitioned() && partitionListener != null) {
-        String partition = newPartitionDirectory.toString();
-        if (!addedPartitions.contains(partition)) {
-          partitionListener.partitionAdded(namespace, name, partition);
-          addedPartitions.add(partition);
-        }
       }
     }
   }

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/PartitionedDatasetWriter.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/PartitionedDatasetWriter.java
@@ -25,6 +25,7 @@ import org.kitesdk.data.spi.FieldPartitioner;
 import org.kitesdk.data.spi.PartitionListener;
 import org.kitesdk.data.spi.StorageKey;
 import org.kitesdk.data.spi.ReaderWriterState;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.cache.CacheBuilder;
@@ -187,7 +188,8 @@ class PartitionedDatasetWriter<E> extends AbstractDatasetWriter<E> {
         .toString();
   }
 
-  private static class DatasetWriterCacheLoader<E> extends
+  @VisibleForTesting
+  static class DatasetWriterCacheLoader<E> extends
     CacheLoader<StorageKey, DatasetWriter<E>> {
 
     private final FileSystemView<E> view;
@@ -217,6 +219,9 @@ class PartitionedDatasetWriter<E> extends AbstractDatasetWriter<E> {
             dataset.getNamespace(), dataset.getName(), partition.toString());
       }
 
+      // initialize the writer after calling the listener
+      // this lets the listener decide if and how to create the
+      // partition directory
       writer.initialize();
 
       return writer;

--- a/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestDatasetWriterCacheLoader.java
+++ b/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestDatasetWriterCacheLoader.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2015 Cloudera, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kitesdk.data.spi.filesystem;
+
+import com.google.common.io.Files;
+import java.io.IOException;
+import junit.framework.Assert;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.kitesdk.data.DatasetDescriptor;
+import org.kitesdk.data.PartitionStrategy;
+import org.kitesdk.data.spi.PartitionListener;
+import org.kitesdk.data.spi.StorageKey;
+import static org.kitesdk.data.spi.filesystem.DatasetTestUtilities.USER_SCHEMA;
+
+public class TestDatasetWriterCacheLoader {
+
+  private Configuration conf;
+  private FileSystem fileSystem;
+  private Path testDirectory;
+  private FileSystemDatasetRepository repo;
+  private PartitionStrategy partitionStrategy;
+  private FileSystemView<Object> view;
+
+  @Before
+  public void setUp() throws IOException {
+    this.conf = new Configuration();
+    this.fileSystem = FileSystem.get(conf);
+    this.testDirectory = new Path(Files.createTempDir().getAbsolutePath());
+    this.repo = new FileSystemDatasetRepository(conf, testDirectory,
+      new EnusrePartitionPathDoesNotExistMetadataProvider(conf, testDirectory));
+
+    partitionStrategy = new PartitionStrategy.Builder()
+      .hash("username", 2).build();
+    FileSystemDataset<Object> users = (FileSystemDataset<Object>) repo.create(
+      "ns", "users",
+      new DatasetDescriptor.Builder()
+      .schema(USER_SCHEMA)
+      .partitionStrategy(partitionStrategy)
+      .build());
+    view = new FileSystemView<Object>(users, Object.class);
+  }
+
+  @After
+  public void tearDown() throws IOException {
+    fileSystem.delete(testDirectory, true);
+  }
+
+  @Test
+  public void testInitializeAfterParitionAddedCallback() throws Exception {
+    PartitionedDatasetWriter.DatasetWriterCacheLoader<Object> loader
+      = new PartitionedDatasetWriter.DatasetWriterCacheLoader<Object>(view);
+
+    StorageKey key = new StorageKey.Builder(partitionStrategy)
+      .add("username", "test1")
+      .build();
+    loader.load(key);
+  }
+
+  private static class EnusrePartitionPathDoesNotExistMetadataProvider
+    extends FileSystemMetadataProvider implements PartitionListener {
+
+    public EnusrePartitionPathDoesNotExistMetadataProvider(Configuration conf, Path rootDirectory) {
+      super(conf, rootDirectory);
+    }
+
+    @Override
+    public void partitionAdded(String namespace, String name, String partition) {
+      Path root = getRootDirectory();
+      Path partitionPath = new Path(
+        FileSystemDatasetRepository.pathForDataset(root, namespace, name),
+        partition);
+      try {
+        Assert.assertFalse("Partition path " + partitionPath + " does not exist",
+          getFileSytem().exists(partitionPath));
+      } catch (IOException ex) {
+        Assert.fail(ex.getMessage());
+      }
+    }
+
+    @Override
+    public void partitionDeleted(String namespace, String name, String partition) {
+    }
+  }
+
+}

--- a/kite-data/kite-data-hive/src/main/java/org/kitesdk/data/spi/hive/HiveExternalMetadataProvider.java
+++ b/kite-data/kite-data-hive/src/main/java/org/kitesdk/data/spi/hive/HiveExternalMetadataProvider.java
@@ -107,4 +107,17 @@ class HiveExternalMetadataProvider extends HiveAbstractMetadataProvider {
     return rootFileSystem.makeQualified(
         HiveUtils.pathForDataset(rootDirectory, namespace, name));
   }
+
+  @Override
+  public void partitionAdded(String namespace, String name, String path) {
+    Path partitionPath = new Path(pathForDataset(namespace, name), path);
+    try {
+      rootFileSystem.mkdirs(partitionPath);
+    } catch (IOException ex) {
+      throw new DatasetIOException(
+        "Unable to create partition directory  " + partitionPath, ex);
+    }
+    super.partitionAdded(namespace, name, path);
+  }
+
 }


### PR DESCRIPTION
- This patch reverses course from the previous one. Depending on the
  dataset implementation, you may or may not want Kite creating the
  directories.
- This patch moves the partitionAdded callback to happen before new
  partition directories are created to give the listener a chance
  to create them in Kite or externally.
- In particular, external Hive datasets will create the directories on
  the Kite side while managed Hive datasets will let the Hive metastore
  create them.
- This doesn't affect file system datasets as they don't have listeners
  regisitered unless they're manulaly created with a custom
  MetadataProvider
- Added a test of `load()` methods of `DatasetWriterCacheLoader` and
  `IncrementalDatasetWriterCacheLoader`.
- Fixed a typo

Conflicts:
    kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/PartitionedDatasetWriter.java
