### PR TITLE
SD-1913: Add mulit-file input to DatasetKeyInputFormat

### DIFF
--- a/kite-data/kite-data-crunch/src/test/java/org/kitesdk/data/crunch/TestCrunchDatasets.java
+++ b/kite-data/kite-data-crunch/src/test/java/org/kitesdk/data/crunch/TestCrunchDatasets.java
@@ -33,6 +33,7 @@ import org.apache.crunch.Pipeline;
 import org.apache.crunch.Target;
 import org.apache.crunch.impl.mr.MRPipeline;
 import org.apache.crunch.types.avro.Avros;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.junit.After;
@@ -55,6 +56,7 @@ import org.kitesdk.data.spi.PartitionedDataset;
 import org.kitesdk.data.View;
 import org.kitesdk.data.spi.LastModifiedAccessor;
 import org.kitesdk.data.URIBuilder;
+import org.kitesdk.data.mapreduce.DatasetKeyInputFormat;
 import org.kitesdk.data.user.NewUserRecord;
 
 import static org.kitesdk.data.spi.filesystem.DatasetTestUtilities.USER_SCHEMA;
@@ -136,6 +138,28 @@ public abstract class TestCrunchDatasets extends MiniDFSTest {
     PCollection<GenericData.Record> data = pipeline.read(
         CrunchDatasets.asSource(inputDataset));
     pipeline.write(data, CrunchDatasets.asTarget(outputDataset), Target.WriteMode.APPEND);
+    pipeline.run();
+
+    checkTestUsers(outputDataset, 10);
+  }
+
+  @Test
+  public void testGenericParquetMultiInputRecordReader() throws IOException {
+    Dataset<Record> inputDataset = repo.create("ns", "in", new DatasetDescriptor.Builder()
+        .schema(USER_SCHEMA).format(Formats.PARQUET).build());
+    Dataset<Record> outputDataset = repo.create("ns", "out", new DatasetDescriptor.Builder()
+        .schema(USER_SCHEMA).format(Formats.PARQUET).build());
+
+    // write two files, each of 5 records
+    writeTestUsers(inputDataset, 5, 0);
+    writeTestUsers(inputDataset, 5, 5);
+
+    Configuration conf = new Configuration();
+    DatasetKeyInputFormat.configure(conf).useMultiInputRecordReader();
+    Pipeline pipeline = new MRPipeline(TestCrunchDatasets.class, conf);
+    PCollection<GenericData.Record> data = pipeline.read(
+        CrunchDatasets.asSource(inputDataset));
+    pipeline.write(data, CrunchDatasets.asTarget((View<Record>)outputDataset), Target.WriteMode.APPEND);
     pipeline.run();
 
     checkTestUsers(outputDataset, 10);

--- a/kite-data/kite-data-mapreduce/src/main/java/org/kitesdk/data/mapreduce/MultiInputRecordReader.java
+++ b/kite-data/kite-data-mapreduce/src/main/java/org/kitesdk/data/mapreduce/MultiInputRecordReader.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2015 ScalingData
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kitesdk.data.mapreduce;
+
+import java.io.IOException;
+import org.apache.hadoop.mapreduce.InputFormat;
+import org.apache.hadoop.mapreduce.InputSplit;
+import org.apache.hadoop.mapreduce.RecordReader;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class MultiInputRecordReader<E> extends RecordReader<E, Void> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(MultiInputRecordReader.class);
+
+  private final InputFormat<E, Void> delegateInputFormat;
+  private MultiInputSplit inputSplit;
+  private TaskAttemptContext attemptContext;
+  private int currentSplitIdx;
+  private RecordReader<E, Void> delegateRecordReader;
+
+  public MultiInputRecordReader(InputFormat<E, Void> delegate) {
+    this.delegateInputFormat = delegate;
+  }
+
+  @Override
+  public void initialize(InputSplit split, TaskAttemptContext context) throws IOException, InterruptedException {
+    if (split instanceof MultiInputSplit) {
+      inputSplit = (MultiInputSplit) split;
+      attemptContext = context;
+      currentSplitIdx = 0;
+
+      LOG.debug("Creating record reader for split: {}",
+        inputSplit.getSplit(currentSplitIdx));
+      delegateRecordReader = delegateInputFormat.createRecordReader(
+        inputSplit.getSplit(currentSplitIdx), attemptContext);
+      delegateRecordReader.initialize(inputSplit.getSplit(currentSplitIdx),
+        attemptContext);
+    } else {
+      throw new RuntimeException("Unexpected type for InputSplit: "
+        + split.getClass().getName());
+    }
+  }
+
+  @Override
+  public boolean nextKeyValue() throws IOException, InterruptedException {
+    boolean hasNext = delegateRecordReader.nextKeyValue();
+
+    while (!hasNext) {
+      LOG.debug("Closing record reader for split: {}",
+        inputSplit.getSplit(currentSplitIdx));
+      delegateRecordReader.close();
+      delegateRecordReader = null;
+
+      currentSplitIdx++;
+      if (!inputSplit.hasSplit(currentSplitIdx)) {
+        return false;
+      }
+
+      LOG.debug("Creating record reader for split: {}",
+        inputSplit.getSplit(currentSplitIdx));
+      delegateRecordReader = delegateInputFormat.createRecordReader(
+          inputSplit.getSplit(currentSplitIdx), attemptContext);
+      delegateRecordReader.initialize(inputSplit.getSplit(currentSplitIdx),
+        attemptContext);
+      hasNext = delegateRecordReader.nextKeyValue();
+    }
+
+    return hasNext;
+  }
+
+  @Override
+  public E getCurrentKey() throws IOException, InterruptedException {
+    return delegateRecordReader.getCurrentKey();
+  }
+
+  @Override
+  public Void getCurrentValue() throws IOException, InterruptedException {
+    return delegateRecordReader.getCurrentValue();
+  }
+
+  @Override
+  public float getProgress() throws IOException, InterruptedException {
+    float baseProgress = ((float)currentSplitIdx)/((float)inputSplit.getNumSplits());
+
+    float delegateProgress = 0.0f;
+    if (delegateRecordReader != null) {
+      delegateProgress = delegateRecordReader.getProgress();
+    }
+    float incrementalProgress = delegateProgress*1.0f/(inputSplit.getNumSplits());
+
+    return baseProgress + incrementalProgress;
+  }
+
+  @Override
+  public void close() throws IOException {
+    if (delegateRecordReader != null) {
+      LOG.warn("Delegate record reader not closed.");
+
+      LOG.debug("Closing record reader for split: {}",
+        inputSplit.getSplit(currentSplitIdx));
+      delegateRecordReader.close();
+      delegateRecordReader = null;
+
+      currentSplitIdx++;
+    }
+  }
+  
+}

--- a/kite-data/kite-data-mapreduce/src/main/java/org/kitesdk/data/mapreduce/MultiInputSplit.java
+++ b/kite-data/kite-data-mapreduce/src/main/java/org/kitesdk/data/mapreduce/MultiInputSplit.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2015 ScalingData
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kitesdk.data.mapreduce;
+
+import com.google.common.collect.Lists;
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.util.List;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.io.Writable;
+import org.apache.hadoop.mapreduce.InputSplit;
+
+public class MultiInputSplit extends InputSplit implements Writable {
+
+  private final List<InputSplit> splits;
+  private String[] locations;
+  private long length;
+
+  public MultiInputSplit() {
+    splits = Lists.newArrayList();
+    length = 0;
+  }
+
+  public MultiInputSplit(String location) {
+    this();
+    this.locations = new String[] { location };
+  }
+
+  @Override
+  public long getLength() throws IOException, InterruptedException {
+    return length;
+  }
+
+  @edu.umd.cs.findbugs.annotations.SuppressWarnings(value="EI_EXPOSE_REP",
+    justification="Safe operation defined by InputSplit interface")
+  @Override
+  public String[] getLocations() throws IOException, InterruptedException {
+    return locations;
+  }
+
+  public void addSplit(InputSplit split) throws IOException, InterruptedException {
+    splits.add(split);
+    length += split.getLength();
+  }
+
+  public InputSplit getSplit(int index) {
+    return splits.get(index);
+  }
+
+  public boolean hasSplit(int index) {
+    return splits.size() > index;
+  }
+
+  public int getNumSplits() {
+    return splits.size();
+  }
+
+  @Override
+  public void write(DataOutput out) throws IOException {
+    out.writeUTF(splits.get(0).getClass().getName());
+    
+    out.writeInt(splits.size());
+    for (InputSplit split : splits) {
+      if (split instanceof Writable) {
+        ((Writable)split).write(out);
+      } else {
+        throw new RuntimeException("Class " + split.getClass().getName()
+          + " does not implement " + Writable.class.getName());
+      }
+    }
+
+    out.writeLong(length);
+  }
+
+  @Override
+  public void readFields(DataInput in) throws IOException {
+
+    String splitClassName = in.readUTF();
+    Class<?> splitClass = new Configuration().getClassByNameOrNull(splitClassName);
+    if (splitClass == null) {
+      throw new RuntimeException("Class " + splitClassName + " not found");
+    }
+
+    if (!Writable.class.isAssignableFrom(splitClass)) {
+      throw new RuntimeException("Class " + splitClassName
+        + " does not implement " + Writable.class.getName());
+    }
+
+    Class<? extends Writable> writableClass = splitClass.asSubclass(Writable.class);
+
+    int nSplits = in.readInt();
+
+    for (int i = 0; i < nSplits; i++) {
+      Writable writable = newWritable(writableClass);
+      writable.readFields(in);
+      splits.add(asInputSplit(writable));
+    }
+
+    this.length = in.readLong();
+  }
+
+  private Writable newWritable(Class<? extends Writable> writableClass) {
+    try {
+      return writableClass.newInstance();
+    } catch (InstantiationException ex) {
+      throw new RuntimeException(ex);
+    } catch (IllegalAccessException ex) {
+      throw new RuntimeException(ex);
+    }
+  }
+
+  private InputSplit asInputSplit(Writable writable) {
+    if (writable instanceof InputSplit) {
+      return (InputSplit) writable;
+    }
+    throw new RuntimeException("Class " + writable.getClass().getName()
+      + " is not a sub-class of " + InputSplit.class.getName());
+  }
+  
+}

--- a/kite-data/kite-data-mapreduce/src/test/java/org/kitesdk/data/mapreduce/TestMapReduce.java
+++ b/kite-data/kite-data-mapreduce/src/test/java/org/kitesdk/data/mapreduce/TestMapReduce.java
@@ -101,6 +101,16 @@ public class TestMapReduce extends FileSystemTestBase {
   }
 
   @Test
+  public void testJobTwoFiles() throws Exception {
+    populateInputDatasetWithTwoFiles();
+
+    Job job = createJob();
+    DatasetKeyInputFormat.configure(job).useMultiInputRecordReader();
+    Assert.assertTrue(job.waitForCompletion(true));
+    checkOutput(false);
+  }
+
+  @Test
   public void testJobEmptyView() throws Exception {
     Job job = createJob();
     Assert.assertTrue(job.waitForCompletion(true));
@@ -163,6 +173,20 @@ public class TestMapReduce extends FileSystemTestBase {
     writer.write(newStringRecord("apple"));
     writer.write(newStringRecord("banana"));
     writer.write(newStringRecord("banana"));
+    writer.write(newStringRecord("carrot"));
+    writer.write(newStringRecord("apple"));
+    writer.write(newStringRecord("apple"));
+    writer.close();
+  }
+
+  private void populateInputDatasetWithTwoFiles() {
+    DatasetWriter<GenericData.Record> writer = inputDataset.newWriter();
+    writer.write(newStringRecord("apple"));
+    writer.write(newStringRecord("banana"));
+    writer.write(newStringRecord("banana"));
+    writer.close();
+
+    writer = inputDataset.newWriter();
     writer.write(newStringRecord("carrot"));
     writer.write(newStringRecord("apple"));
     writer.write(newStringRecord("apple"));


### PR DESCRIPTION
This adds an optional MultiInputRecordReader implementation.
It will batch the underlying InputSplits together by location
and create splits that are roughly 256MB in size. This is disabled
by default, but can be enabled by calling:

```
DatasetKeyInputFormat.configure(job).useMultiInputRecordReader();
```
