### PR TITLE
ROCANA-3905: Release Kite fork 1.3.0 and update parent

### DIFF
--- a/kite-app-parent/cdh5/pom.xml
+++ b/kite-app-parent/cdh5/pom.xml
@@ -26,7 +26,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.kitesdk</groupId>
   <artifactId>kite-app-parent-cdh5</artifactId>
-  <version>1.0.0-cdh5.4.0-rocana1.2.0-SNAPSHOT</version>
+  <version>1.0.0-cdh5.4.0-rocana1.3.0</version>
   <packaging>pom</packaging>
 
   <name>Kite Application POM for CDH5</name>

--- a/kite-app-parent/pom.xml
+++ b/kite-app-parent/pom.xml
@@ -19,13 +19,13 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.kitesdk</groupId>
   <artifactId>kite-app-parent-modules</artifactId>
-  <version>1.0.0-cdh5.4.0-rocana1.2.0-SNAPSHOT</version>
+  <version>1.0.0-cdh5.4.0-rocana1.3.0</version>
   <packaging>pom</packaging>
 
   <parent>
     <groupId>org.kitesdk</groupId>
     <artifactId>kite-parent</artifactId>
-    <version>1.0.0-cdh5.4.0-rocana1.2.0-SNAPSHOT</version>
+    <version>1.0.0-cdh5.4.0-rocana1.3.0</version>
   </parent>
 
   <name>Kite Application POM Modules</name>

--- a/kite-data/kite-data-core/pom.xml
+++ b/kite-data/kite-data-core/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.kitesdk</groupId>
     <artifactId>kite-data</artifactId>
-    <version>1.0.0-cdh5.4.0-rocana1.3.0-SNAPSHOT</version>
+    <version>1.0.0-cdh5.4.0-rocana1.3.0</version>
   </parent>
 
   <name>Kite Data Core Module</name>

--- a/kite-data/kite-data-crunch/pom.xml
+++ b/kite-data/kite-data-crunch/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.kitesdk</groupId>
     <artifactId>kite-data</artifactId>
-    <version>1.0.0-cdh5.4.0-rocana1.3.0-SNAPSHOT</version>
+    <version>1.0.0-cdh5.4.0-rocana1.3.0</version>
   </parent>
 
   <name>Kite Data Crunch Module</name>

--- a/kite-data/kite-data-flume/pom.xml
+++ b/kite-data/kite-data-flume/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.kitesdk</groupId>
     <artifactId>kite-data</artifactId>
-    <version>1.0.0-cdh5.4.0-rocana1.2.0-SNAPSHOT</version>
+    <version>1.0.0-cdh5.4.0-rocana1.3.0</version>
   </parent>
 
   <name>Kite Data Flume Module</name>
@@ -102,7 +102,7 @@
     <dependency>
       <groupId>org.kitesdk</groupId>
       <artifactId>kite-data-core</artifactId>
-      <version>1.0.0-cdh5.4.0-rocana1.2.0-SNAPSHOT</version>
+      <version>1.0.0-cdh5.4.0-rocana1.3.0</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/kite-data/kite-data-hbase/pom.xml
+++ b/kite-data/kite-data-hbase/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.kitesdk</groupId>
     <artifactId>kite-data</artifactId>
-    <version>1.0.0-cdh5.4.0-rocana1.3.0-SNAPSHOT</version>
+    <version>1.0.0-cdh5.4.0-rocana1.3.0</version>
   </parent>
 
   <name>Kite Data HBase Module</name>
@@ -171,7 +171,7 @@
     <dependency>
       <groupId>org.kitesdk</groupId>
       <artifactId>kite-data-core</artifactId>
-      <version>1.0.0-cdh5.4.0-rocana1.3.0-SNAPSHOT</version>
+      <version>1.0.0-cdh5.4.0-rocana1.3.0</version>
     </dependency>
 
     <!-- Hadoop and HBase -->
@@ -228,7 +228,7 @@
     <dependency>
       <groupId>org.kitesdk</groupId>
       <artifactId>kite-data-core</artifactId>
-      <version>1.0.0-cdh5.4.0-rocana1.3.0-SNAPSHOT</version>
+      <version>1.0.0-cdh5.4.0-rocana1.3.0</version>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>

--- a/kite-data/kite-data-hive/pom.xml
+++ b/kite-data/kite-data-hive/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.kitesdk</groupId>
     <artifactId>kite-data</artifactId>
-    <version>1.0.0-cdh5.4.0-rocana1.3.0-SNAPSHOT</version>
+    <version>1.0.0-cdh5.4.0-rocana1.3.0</version>
   </parent>
 
   <name>Kite Data Hive Module</name>

--- a/kite-data/kite-data-mapreduce/pom.xml
+++ b/kite-data/kite-data-mapreduce/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.kitesdk</groupId>
     <artifactId>kite-data</artifactId>
-    <version>1.0.0-cdh5.4.0-rocana1.3.0-SNAPSHOT</version>
+    <version>1.0.0-cdh5.4.0-rocana1.3.0</version>
   </parent>
 
   <name>Kite Data MapReduce Module</name>

--- a/kite-data/kite-data-spark/pom.xml
+++ b/kite-data/kite-data-spark/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.kitesdk</groupId>
     <artifactId>kite-data</artifactId>
-    <version>1.0.0-cdh5.4.0-rocana1.3.0-SNAPSHOT</version>
+    <version>1.0.0-cdh5.4.0-rocana1.3.0</version>
   </parent>
 
   <name>Kite Data Spark Module</name>

--- a/kite-data/pom.xml
+++ b/kite-data/pom.xml
@@ -36,7 +36,7 @@
   <parent>
     <groupId>org.kitesdk</groupId>
     <artifactId>kite-parent</artifactId>
-    <version>1.0.0-cdh5.4.0-rocana1.3.0-SNAPSHOT</version>
+    <version>1.0.0-cdh5.4.0-rocana1.3.0</version>
   </parent>
 
   <name>Kite Data Module</name>

--- a/kite-hadoop-compatibility/pom.xml
+++ b/kite-hadoop-compatibility/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.kitesdk</groupId>
     <artifactId>kite-parent</artifactId>
-    <version>1.0.0-cdh5.4.0-rocana1.3.0-SNAPSHOT</version>
+    <version>1.0.0-cdh5.4.0-rocana1.3.0</version>
   </parent>
 
   <name>Kite Hadoop Compatibility Module</name>

--- a/kite-hadoop-dependencies/cdh4-test/pom.xml
+++ b/kite-hadoop-dependencies/cdh4-test/pom.xml
@@ -19,12 +19,12 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>kite-hadoop-cdh4-test-dependencies</artifactId>
   <packaging>pom</packaging>
-  <version>1.0.0-cdh5.4.0-rocana1.2.0-SNAPSHOT</version>
+  <version>1.0.0-cdh5.4.0-rocana1.3.0</version>
 
   <parent>
     <groupId>org.kitesdk</groupId>
     <artifactId>kite-hadoop-deps-parent</artifactId>
-    <version>1.0.0-cdh5.4.0-rocana1.2.0-SNAPSHOT</version>
+    <version>1.0.0-cdh5.4.0-rocana1.3.0</version>
   </parent>
 
   <name>Kite Hadoop CDH4 Test Dependencies Module</name>

--- a/kite-hadoop-dependencies/cdh4/pom.xml
+++ b/kite-hadoop-dependencies/cdh4/pom.xml
@@ -19,12 +19,12 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>kite-hadoop-cdh4-dependencies</artifactId>
   <packaging>pom</packaging>
-  <version>1.0.0-cdh5.4.0-rocana1.2.0-SNAPSHOT</version>
+  <version>1.0.0-cdh5.4.0-rocana1.3.0</version>
 
   <parent>
     <groupId>org.kitesdk</groupId>
     <artifactId>kite-hadoop-deps-parent</artifactId>
-    <version>1.0.0-cdh5.4.0-rocana1.2.0-SNAPSHOT</version>
+    <version>1.0.0-cdh5.4.0-rocana1.3.0</version>
   </parent>
 
   <name>Kite Hadoop CDH4 Dependencies Module</name>

--- a/kite-hadoop-dependencies/cdh5-test/pom.xml
+++ b/kite-hadoop-dependencies/cdh5-test/pom.xml
@@ -19,12 +19,12 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>kite-hadoop-cdh5-test-dependencies</artifactId>
   <packaging>pom</packaging>
-  <version>1.0.0-cdh5.4.0-rocana1.3.0-SNAPSHOT</version>
+  <version>1.0.0-cdh5.4.0-rocana1.3.0</version>
 
   <parent>
     <groupId>org.kitesdk</groupId>
     <artifactId>kite-hadoop-deps-parent</artifactId>
-    <version>1.0.0-cdh5.4.0-rocana1.3.0-SNAPSHOT</version>
+    <version>1.0.0-cdh5.4.0-rocana1.3.0</version>
   </parent>
 
   <name>Kite Hadoop CDH5 Test Dependencies Module</name>

--- a/kite-hadoop-dependencies/cdh5/pom.xml
+++ b/kite-hadoop-dependencies/cdh5/pom.xml
@@ -19,12 +19,12 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>kite-hadoop-cdh5-dependencies</artifactId>
   <packaging>pom</packaging>
-  <version>1.0.0-cdh5.4.0-rocana1.3.0-SNAPSHOT</version>
+  <version>1.0.0-cdh5.4.0-rocana1.3.0</version>
 
   <parent>
     <groupId>org.kitesdk</groupId>
     <artifactId>kite-hadoop-deps-parent</artifactId>
-    <version>1.0.0-cdh5.4.0-rocana1.3.0-SNAPSHOT</version>
+    <version>1.0.0-cdh5.4.0-rocana1.3.0</version>
   </parent>
 
   <name>Kite Hadoop CDH5 Dependencies Module</name>

--- a/kite-hadoop-dependencies/default-test/pom.xml
+++ b/kite-hadoop-dependencies/default-test/pom.xml
@@ -19,12 +19,12 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>kite-hadoop-test-dependencies</artifactId>
   <packaging>pom</packaging>
-  <version>1.0.0-cdh5.4.0-rocana1.2.0-SNAPSHOT</version>
+  <version>1.0.0-cdh5.4.0-rocana1.3.0</version>
 
   <parent>
     <groupId>org.kitesdk</groupId>
     <artifactId>kite-hadoop-deps-parent</artifactId>
-    <version>1.0.0-cdh5.4.0-rocana1.2.0-SNAPSHOT</version>
+    <version>1.0.0-cdh5.4.0-rocana1.3.0</version>
   </parent>
 
   <name>Kite Hadoop Default Test Dependencies Module</name>

--- a/kite-hadoop-dependencies/default/pom.xml
+++ b/kite-hadoop-dependencies/default/pom.xml
@@ -19,12 +19,12 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>kite-hadoop-dependencies</artifactId>
   <packaging>pom</packaging>
-  <version>1.0.0-cdh5.4.0-rocana1.2.0-SNAPSHOT</version>
+  <version>1.0.0-cdh5.4.0-rocana1.3.0</version>
 
   <parent>
     <groupId>org.kitesdk</groupId>
     <artifactId>kite-hadoop-deps-parent</artifactId>
-    <version>1.0.0-cdh5.4.0-rocana1.2.0-SNAPSHOT</version>
+    <version>1.0.0-cdh5.4.0-rocana1.3.0</version>
   </parent>
 
   <name>Kite Hadoop Default Dependencies Module</name>

--- a/kite-hadoop-dependencies/hadoop1-test/pom.xml
+++ b/kite-hadoop-dependencies/hadoop1-test/pom.xml
@@ -19,12 +19,12 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>kite-hadoop1-test-dependencies</artifactId>
   <packaging>pom</packaging>
-  <version>1.0.0-cdh5.4.0-rocana1.2.0-SNAPSHOT</version>
+  <version>1.0.0-cdh5.4.0-rocana1.3.0</version>
 
   <parent>
     <groupId>org.kitesdk</groupId>
     <artifactId>kite-hadoop-deps-parent</artifactId>
-    <version>1.0.0-cdh5.4.0-rocana1.2.0-SNAPSHOT</version>
+    <version>1.0.0-cdh5.4.0-rocana1.3.0</version>
   </parent>
 
   <name>Kite Hadoop-1 Test Dependencies Module</name>

--- a/kite-hadoop-dependencies/hadoop1/pom.xml
+++ b/kite-hadoop-dependencies/hadoop1/pom.xml
@@ -19,12 +19,12 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>kite-hadoop1-dependencies</artifactId>
   <packaging>pom</packaging>
-  <version>1.0.0-cdh5.4.0-rocana1.2.0-SNAPSHOT</version>
+  <version>1.0.0-cdh5.4.0-rocana1.3.0</version>
 
   <parent>
     <groupId>org.kitesdk</groupId>
     <artifactId>kite-hadoop-deps-parent</artifactId>
-    <version>1.0.0-cdh5.4.0-rocana1.2.0-SNAPSHOT</version>
+    <version>1.0.0-cdh5.4.0-rocana1.3.0</version>
   </parent>
 
   <name>Kite Hadoop-1 Dependencies Module</name>

--- a/kite-hadoop-dependencies/hdp2-test/pom.xml
+++ b/kite-hadoop-dependencies/hdp2-test/pom.xml
@@ -19,12 +19,12 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>kite-hadoop-hdp2-test-dependencies</artifactId>
   <packaging>pom</packaging>
-  <version>1.0.0-cdh5.4.0-rocana1.3.0-SNAPSHOT</version>
+  <version>1.0.0-cdh5.4.0-rocana1.3.0</version>
 
   <parent>
     <groupId>org.kitesdk</groupId>
     <artifactId>kite-hadoop-deps-parent</artifactId>
-    <version>1.0.0-cdh5.4.0-rocana1.3.0-SNAPSHOT</version>
+    <version>1.0.0-cdh5.4.0-rocana1.3.0</version>
   </parent>
 
   <name>Kite Hadoop HDP2 Test Dependencies Module</name>

--- a/kite-hadoop-dependencies/hdp2/pom.xml
+++ b/kite-hadoop-dependencies/hdp2/pom.xml
@@ -19,12 +19,12 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>kite-hadoop-hdp2-dependencies</artifactId>
   <packaging>pom</packaging>
-  <version>1.0.0-cdh5.4.0-rocana1.3.0-SNAPSHOT</version>
+  <version>1.0.0-cdh5.4.0-rocana1.3.0</version>
 
   <parent>
     <groupId>org.kitesdk</groupId>
     <artifactId>kite-hadoop-deps-parent</artifactId>
-    <version>1.0.0-cdh5.4.0-rocana1.3.0-SNAPSHOT</version>
+    <version>1.0.0-cdh5.4.0-rocana1.3.0</version>
   </parent>
 
   <name>Kite Hadoop HDP2 Dependencies Module</name>

--- a/kite-hadoop-dependencies/pom.xml
+++ b/kite-hadoop-dependencies/pom.xml
@@ -38,7 +38,7 @@
   <parent>
     <groupId>org.kitesdk</groupId>
     <artifactId>kite-parent</artifactId>
-    <version>1.0.0-cdh5.4.0-rocana1.3.0-SNAPSHOT</version>
+    <version>1.0.0-cdh5.4.0-rocana1.3.0</version>
   </parent>
 
   <name>Kite Hadoop Dependencies Module</name>

--- a/kite-hbase-dependencies/cdh4-test/pom.xml
+++ b/kite-hbase-dependencies/cdh4-test/pom.xml
@@ -19,12 +19,12 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>kite-hbase-cdh4-test-dependencies</artifactId>
   <packaging>pom</packaging>
-  <version>1.0.0-cdh5.4.0-rocana1.2.0-SNAPSHOT</version>
+  <version>1.0.0-cdh5.4.0-rocana1.3.0</version>
 
   <parent>
     <groupId>org.kitesdk</groupId>
     <artifactId>kite-hbase-deps-parent</artifactId>
-    <version>1.0.0-cdh5.4.0-rocana1.2.0-SNAPSHOT</version>
+    <version>1.0.0-cdh5.4.0-rocana1.3.0</version>
   </parent>
 
   <name>Kite HBase CDH4 Test Dependencies Module</name>

--- a/kite-hbase-dependencies/cdh4/pom.xml
+++ b/kite-hbase-dependencies/cdh4/pom.xml
@@ -19,12 +19,12 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>kite-hbase-cdh4-dependencies</artifactId>
   <packaging>pom</packaging>
-  <version>1.0.0-cdh5.4.0-rocana1.2.0-SNAPSHOT</version>
+  <version>1.0.0-cdh5.4.0-rocana1.3.0</version>
 
   <parent>
     <groupId>org.kitesdk</groupId>
     <artifactId>kite-hbase-deps-parent</artifactId>
-    <version>1.0.0-cdh5.4.0-rocana1.2.0-SNAPSHOT</version>
+    <version>1.0.0-cdh5.4.0-rocana1.3.0</version>
   </parent>
 
   <name>Kite HBase CDH4 Dependencies Module</name>

--- a/kite-hbase-dependencies/cdh5-test/pom.xml
+++ b/kite-hbase-dependencies/cdh5-test/pom.xml
@@ -19,12 +19,12 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>kite-hbase-cdh5-test-dependencies</artifactId>
   <packaging>pom</packaging>
-  <version>1.0.0-cdh5.4.0-rocana1.3.0-SNAPSHOT</version>
+  <version>1.0.0-cdh5.4.0-rocana1.3.0</version>
 
   <parent>
     <groupId>org.kitesdk</groupId>
     <artifactId>kite-hbase-deps-parent</artifactId>
-    <version>1.0.0-cdh5.4.0-rocana1.3.0-SNAPSHOT</version>
+    <version>1.0.0-cdh5.4.0-rocana1.3.0</version>
   </parent>
 
   <name>Kite HBase CDH5 Test Dependencies Module</name>

--- a/kite-hbase-dependencies/cdh5/pom.xml
+++ b/kite-hbase-dependencies/cdh5/pom.xml
@@ -19,12 +19,12 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>kite-hbase-cdh5-dependencies</artifactId>
   <packaging>pom</packaging>
-  <version>1.0.0-cdh5.4.0-rocana1.3.0-SNAPSHOT</version>
+  <version>1.0.0-cdh5.4.0-rocana1.3.0</version>
 
   <parent>
     <groupId>org.kitesdk</groupId>
     <artifactId>kite-hbase-deps-parent</artifactId>
-    <version>1.0.0-cdh5.4.0-rocana1.3.0-SNAPSHOT</version>
+    <version>1.0.0-cdh5.4.0-rocana1.3.0</version>
   </parent>
 
   <name>Kite HBase CDH5 Dependencies Module</name>

--- a/kite-hbase-dependencies/default-test/pom.xml
+++ b/kite-hbase-dependencies/default-test/pom.xml
@@ -19,12 +19,12 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>kite-hbase-test-dependencies</artifactId>
   <packaging>pom</packaging>
-  <version>1.0.0-cdh5.4.0-rocana1.2.0-SNAPSHOT</version>
+  <version>1.0.0-cdh5.4.0-rocana1.3.0</version>
 
   <parent>
     <groupId>org.kitesdk</groupId>
     <artifactId>kite-hbase-deps-parent</artifactId>
-    <version>1.0.0-cdh5.4.0-rocana1.2.0-SNAPSHOT</version>
+    <version>1.0.0-cdh5.4.0-rocana1.3.0</version>
   </parent>
 
   <name>Kite HBase Default Test Dependencies Module</name>

--- a/kite-hbase-dependencies/default/pom.xml
+++ b/kite-hbase-dependencies/default/pom.xml
@@ -19,12 +19,12 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>kite-hbase-dependencies</artifactId>
   <packaging>pom</packaging>
-  <version>1.0.0-cdh5.4.0-rocana1.2.0-SNAPSHOT</version>
+  <version>1.0.0-cdh5.4.0-rocana1.3.0</version>
 
   <parent>
     <groupId>org.kitesdk</groupId>
     <artifactId>kite-hbase-deps-parent</artifactId>
-    <version>1.0.0-cdh5.4.0-rocana1.2.0-SNAPSHOT</version>
+    <version>1.0.0-cdh5.4.0-rocana1.3.0</version>
   </parent>
 
   <name>Kite HBase Default Dependencies Module</name>

--- a/kite-hbase-dependencies/hadoop1-test/pom.xml
+++ b/kite-hbase-dependencies/hadoop1-test/pom.xml
@@ -19,12 +19,12 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>kite-hbase1-test-dependencies</artifactId>
   <packaging>pom</packaging>
-  <version>1.0.0-cdh5.4.0-rocana1.2.0-SNAPSHOT</version>
+  <version>1.0.0-cdh5.4.0-rocana1.3.0</version>
 
   <parent>
     <groupId>org.kitesdk</groupId>
     <artifactId>kite-hbase-deps-parent</artifactId>
-    <version>1.0.0-cdh5.4.0-rocana1.2.0-SNAPSHOT</version>
+    <version>1.0.0-cdh5.4.0-rocana1.3.0</version>
   </parent>
 
   <name>Kite HBase Hadoop-1 Test Dependencies Module</name>

--- a/kite-hbase-dependencies/hadoop1/pom.xml
+++ b/kite-hbase-dependencies/hadoop1/pom.xml
@@ -19,12 +19,12 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>kite-hbase1-dependencies</artifactId>
   <packaging>pom</packaging>
-  <version>1.0.0-cdh5.4.0-rocana1.2.0-SNAPSHOT</version>
+  <version>1.0.0-cdh5.4.0-rocana1.3.0</version>
 
   <parent>
     <groupId>org.kitesdk</groupId>
     <artifactId>kite-hbase-deps-parent</artifactId>
-    <version>1.0.0-cdh5.4.0-rocana1.2.0-SNAPSHOT</version>
+    <version>1.0.0-cdh5.4.0-rocana1.3.0</version>
   </parent>
 
   <name>Kite HBase Hadoop-1 Dependencies Module</name>

--- a/kite-hbase-dependencies/hdp2-test/pom.xml
+++ b/kite-hbase-dependencies/hdp2-test/pom.xml
@@ -19,12 +19,12 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>kite-hbase-hdp2-test-dependencies</artifactId>
   <packaging>pom</packaging>
-  <version>1.0.0-cdh5.4.0-rocana1.3.0-SNAPSHOT</version>
+  <version>1.0.0-cdh5.4.0-rocana1.3.0</version>
 
   <parent>
     <groupId>org.kitesdk</groupId>
     <artifactId>kite-hbase-deps-parent</artifactId>
-    <version>1.0.0-cdh5.4.0-rocana1.3.0-SNAPSHOT</version>
+    <version>1.0.0-cdh5.4.0-rocana1.3.0</version>
   </parent>
 
   <name>Kite HBase HDP2 Test Dependencies Module</name>

--- a/kite-hbase-dependencies/hdp2/pom.xml
+++ b/kite-hbase-dependencies/hdp2/pom.xml
@@ -19,12 +19,12 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>kite-hbase-hdp2-dependencies</artifactId>
   <packaging>pom</packaging>
-  <version>1.0.0-cdh5.4.0-rocana1.3.0-SNAPSHOT</version>
+  <version>1.0.0-cdh5.4.0-rocana1.3.0</version>
 
   <parent>
     <groupId>org.kitesdk</groupId>
     <artifactId>kite-hbase-deps-parent</artifactId>
-    <version>1.0.0-cdh5.4.0-rocana1.3.0-SNAPSHOT</version>
+    <version>1.0.0-cdh5.4.0-rocana1.3.0</version>
   </parent>
 
   <name>Kite HBase HDP2 Dependencies Module</name>

--- a/kite-hbase-dependencies/pom.xml
+++ b/kite-hbase-dependencies/pom.xml
@@ -38,7 +38,7 @@
   <parent>
     <groupId>org.kitesdk</groupId>
     <artifactId>kite-parent</artifactId>
-    <version>1.0.0-cdh5.4.0-rocana1.3.0-SNAPSHOT</version>
+    <version>1.0.0-cdh5.4.0-rocana1.3.0</version>
   </parent>
 
   <name>Kite HBase Dependencies Module</name>

--- a/kite-maven-plugin/pom.xml
+++ b/kite-maven-plugin/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.kitesdk</groupId>
     <artifactId>kite-parent</artifactId>
-    <version>1.0.0-cdh5.4.0-rocana1.3.0-SNAPSHOT</version>
+    <version>1.0.0-cdh5.4.0-rocana1.3.0</version>
   </parent>
 
   <name>Kite Maven Plugin</name>
@@ -74,12 +74,12 @@
     <dependency>
       <groupId>org.kitesdk</groupId>
       <artifactId>kite-data-core</artifactId>
-      <version>1.0.0-cdh5.4.0-rocana1.3.0-SNAPSHOT</version>
+      <version>1.0.0-cdh5.4.0-rocana1.3.0</version>
     </dependency>
     <dependency>
       <groupId>org.kitesdk</groupId>
       <artifactId>kite-data-hive</artifactId>
-      <version>1.0.0-cdh5.4.0-rocana1.3.0-SNAPSHOT</version>
+      <version>1.0.0-cdh5.4.0-rocana1.3.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>

--- a/kite-minicluster/pom.xml
+++ b/kite-minicluster/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>org.kitesdk</groupId>
     <artifactId>kite-parent</artifactId>
-    <version>1.0.0-cdh5.4.0-rocana1.3.0-SNAPSHOT</version>
+    <version>1.0.0-cdh5.4.0-rocana1.3.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/kite-morphlines/kite-morphlines-all-except-solr/pom.xml
+++ b/kite-morphlines/kite-morphlines-all-except-solr/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>org.kitesdk</groupId>
     <artifactId>kite-morphlines</artifactId>
-    <version>1.0.0-cdh5.4.0-rocana1.2.0-SNAPSHOT</version>
+    <version>1.0.0-cdh5.4.0-rocana1.3.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/kite-morphlines/kite-morphlines-all/pom.xml
+++ b/kite-morphlines/kite-morphlines-all/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>org.kitesdk</groupId>
     <artifactId>kite-morphlines</artifactId>
-    <version>1.0.0-cdh5.4.0-rocana1.2.0-SNAPSHOT</version>
+    <version>1.0.0-cdh5.4.0-rocana1.3.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/kite-morphlines/kite-morphlines-avro/pom.xml
+++ b/kite-morphlines/kite-morphlines-avro/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>org.kitesdk</groupId>
     <artifactId>kite-morphlines</artifactId>
-    <version>1.0.0-cdh5.4.0-rocana1.2.0-SNAPSHOT</version>
+    <version>1.0.0-cdh5.4.0-rocana1.3.0</version>
   </parent>
 
   <artifactId>kite-morphlines-avro</artifactId>

--- a/kite-morphlines/kite-morphlines-core/pom.xml
+++ b/kite-morphlines/kite-morphlines-core/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>org.kitesdk</groupId>
     <artifactId>kite-morphlines</artifactId>
-    <version>1.0.0-cdh5.4.0-rocana1.2.0-SNAPSHOT</version>
+    <version>1.0.0-cdh5.4.0-rocana1.3.0</version>
   </parent>
 
   <artifactId>kite-morphlines-core</artifactId>

--- a/kite-morphlines/kite-morphlines-hadoop-core/pom.xml
+++ b/kite-morphlines/kite-morphlines-hadoop-core/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>org.kitesdk</groupId>
     <artifactId>kite-morphlines</artifactId>
-    <version>1.0.0-cdh5.4.0-rocana1.2.0-SNAPSHOT</version>
+    <version>1.0.0-cdh5.4.0-rocana1.3.0</version>
   </parent>
 
   <artifactId>kite-morphlines-hadoop-core</artifactId>

--- a/kite-morphlines/kite-morphlines-hadoop-parquet-avro/pom.xml
+++ b/kite-morphlines/kite-morphlines-hadoop-parquet-avro/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>org.kitesdk</groupId>
     <artifactId>kite-morphlines</artifactId>
-    <version>1.0.0-cdh5.4.0-rocana1.2.0-SNAPSHOT</version>
+    <version>1.0.0-cdh5.4.0-rocana1.3.0</version>
   </parent>
 
   <artifactId>kite-morphlines-hadoop-parquet-avro</artifactId>

--- a/kite-morphlines/kite-morphlines-hadoop-rcfile/pom.xml
+++ b/kite-morphlines/kite-morphlines-hadoop-rcfile/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>org.kitesdk</groupId>
     <artifactId>kite-morphlines</artifactId>
-    <version>1.0.0-cdh5.4.0-rocana1.2.0-SNAPSHOT</version>
+    <version>1.0.0-cdh5.4.0-rocana1.3.0</version>
   </parent>
 
   <artifactId>kite-morphlines-hadoop-rcfile</artifactId>

--- a/kite-morphlines/kite-morphlines-hadoop-sequencefile/pom.xml
+++ b/kite-morphlines/kite-morphlines-hadoop-sequencefile/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>org.kitesdk</groupId>
     <artifactId>kite-morphlines</artifactId>
-    <version>1.0.0-cdh5.4.0-rocana1.2.0-SNAPSHOT</version>
+    <version>1.0.0-cdh5.4.0-rocana1.3.0</version>
   </parent>
 
   <artifactId>kite-morphlines-hadoop-sequencefile</artifactId>

--- a/kite-morphlines/kite-morphlines-json/pom.xml
+++ b/kite-morphlines/kite-morphlines-json/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>org.kitesdk</groupId>
     <artifactId>kite-morphlines</artifactId>
-    <version>1.0.0-cdh5.4.0-rocana1.2.0-SNAPSHOT</version>
+    <version>1.0.0-cdh5.4.0-rocana1.3.0</version>
   </parent>
 
   <artifactId>kite-morphlines-json</artifactId>

--- a/kite-morphlines/kite-morphlines-maxmind/pom.xml
+++ b/kite-morphlines/kite-morphlines-maxmind/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>org.kitesdk</groupId>
     <artifactId>kite-morphlines</artifactId>
-    <version>1.0.0-cdh5.4.0-rocana1.2.0-SNAPSHOT</version>
+    <version>1.0.0-cdh5.4.0-rocana1.3.0</version>
   </parent>
 
   <artifactId>kite-morphlines-maxmind</artifactId>

--- a/kite-morphlines/kite-morphlines-metrics-servlets/pom.xml
+++ b/kite-morphlines/kite-morphlines-metrics-servlets/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>org.kitesdk</groupId>
     <artifactId>kite-morphlines</artifactId>
-    <version>1.0.0-cdh5.4.0-rocana1.2.0-SNAPSHOT</version>
+    <version>1.0.0-cdh5.4.0-rocana1.3.0</version>
   </parent>
 
   <artifactId>kite-morphlines-metrics-servlets</artifactId>

--- a/kite-morphlines/kite-morphlines-protobuf/pom.xml
+++ b/kite-morphlines/kite-morphlines-protobuf/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>org.kitesdk</groupId>
     <artifactId>kite-morphlines</artifactId>
-    <version>1.0.0-cdh5.4.0-rocana1.2.0-SNAPSHOT</version>
+    <version>1.0.0-cdh5.4.0-rocana1.3.0</version>
   </parent>
   <artifactId>kite-morphlines-protobuf</artifactId>
 

--- a/kite-morphlines/kite-morphlines-saxon/pom.xml
+++ b/kite-morphlines/kite-morphlines-saxon/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>org.kitesdk</groupId>
     <artifactId>kite-morphlines</artifactId>
-    <version>1.0.0-cdh5.4.0-rocana1.2.0-SNAPSHOT</version>
+    <version>1.0.0-cdh5.4.0-rocana1.3.0</version>
   </parent>
 
   <artifactId>kite-morphlines-saxon</artifactId>

--- a/kite-morphlines/kite-morphlines-solr-cell/pom.xml
+++ b/kite-morphlines/kite-morphlines-solr-cell/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>org.kitesdk</groupId>
     <artifactId>kite-morphlines</artifactId>
-    <version>1.0.0-cdh5.4.0-rocana1.2.0-SNAPSHOT</version>
+    <version>1.0.0-cdh5.4.0-rocana1.3.0</version>
   </parent>
 
   <artifactId>kite-morphlines-solr-cell</artifactId>

--- a/kite-morphlines/kite-morphlines-solr-core/pom.xml
+++ b/kite-morphlines/kite-morphlines-solr-core/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>org.kitesdk</groupId>
     <artifactId>kite-morphlines</artifactId>
-    <version>1.0.0-cdh5.4.0-rocana1.2.0-SNAPSHOT</version>
+    <version>1.0.0-cdh5.4.0-rocana1.3.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/kite-morphlines/kite-morphlines-tika-core/pom.xml
+++ b/kite-morphlines/kite-morphlines-tika-core/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>org.kitesdk</groupId>
     <artifactId>kite-morphlines</artifactId>
-    <version>1.0.0-cdh5.4.0-rocana1.2.0-SNAPSHOT</version>
+    <version>1.0.0-cdh5.4.0-rocana1.3.0</version>
   </parent>
 
   <artifactId>kite-morphlines-tika-core</artifactId>

--- a/kite-morphlines/kite-morphlines-tika-decompress/pom.xml
+++ b/kite-morphlines/kite-morphlines-tika-decompress/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>org.kitesdk</groupId>
     <artifactId>kite-morphlines</artifactId>
-    <version>1.0.0-cdh5.4.0-rocana1.2.0-SNAPSHOT</version>
+    <version>1.0.0-cdh5.4.0-rocana1.3.0</version>
   </parent>
 
   <artifactId>kite-morphlines-tika-decompress</artifactId>

--- a/kite-morphlines/kite-morphlines-twitter/pom.xml
+++ b/kite-morphlines/kite-morphlines-twitter/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>org.kitesdk</groupId>
     <artifactId>kite-morphlines</artifactId>
-    <version>1.0.0-cdh5.4.0-rocana1.2.0-SNAPSHOT</version>
+    <version>1.0.0-cdh5.4.0-rocana1.3.0</version>
   </parent>
 
   <artifactId>kite-morphlines-twitter</artifactId>

--- a/kite-morphlines/kite-morphlines-useragent/pom.xml
+++ b/kite-morphlines/kite-morphlines-useragent/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>org.kitesdk</groupId>
     <artifactId>kite-morphlines</artifactId>
-    <version>1.0.0-cdh5.4.0-rocana1.2.0-SNAPSHOT</version>
+    <version>1.0.0-cdh5.4.0-rocana1.3.0</version>
   </parent>
 
   <artifactId>kite-morphlines-useragent</artifactId>

--- a/kite-morphlines/pom.xml
+++ b/kite-morphlines/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>org.kitesdk</groupId>
     <artifactId>kite-parent</artifactId>
-    <version>1.0.0-cdh5.4.0-rocana1.2.0-SNAPSHOT</version>
+    <version>1.0.0-cdh5.4.0-rocana1.3.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/kite-tools-parent/kite-tools-cdh5/pom.xml
+++ b/kite-tools-parent/kite-tools-cdh5/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.kitesdk</groupId>
     <artifactId>kite-tools-parent</artifactId>
-    <version>1.0.0-cdh5.4.0-rocana1.3.0-SNAPSHOT</version>
+    <version>1.0.0-cdh5.4.0-rocana1.3.0</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/kite-tools-parent/kite-tools/pom.xml
+++ b/kite-tools-parent/kite-tools/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.kitesdk</groupId>
     <artifactId>kite-tools-parent</artifactId>
-    <version>1.0.0-cdh5.4.0-rocana1.3.0-SNAPSHOT</version>
+    <version>1.0.0-cdh5.4.0-rocana1.3.0</version>
   </parent>
 
   <name>Kite Tools Runtime Module</name>

--- a/kite-tools-parent/pom.xml
+++ b/kite-tools-parent/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.kitesdk</groupId>
     <artifactId>kite-parent</artifactId>
-    <version>1.0.0-cdh5.4.0-rocana1.3.0-SNAPSHOT</version>
+    <version>1.0.0-cdh5.4.0-rocana1.3.0</version>
   </parent>
 
   <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.kitesdk</groupId>
   <artifactId>kite-parent</artifactId>
-  <version>1.0.0-cdh5.4.0-rocana1.3.0-SNAPSHOT</version>
+  <version>1.0.0-cdh5.4.0-rocana1.3.0</version>
   <packaging>pom</packaging>
 
   <modules>


### PR DESCRIPTION
I found 1.3.0-SNAPSHOT and 1.2.0 in there, I assume they should all be 1.3.0?
